### PR TITLE
Feat/mobile navbar

### DIFF
--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -19,10 +19,10 @@ const useStyles = makeStyles((theme) => ({
   toolbarTitle: {
     flex: 1,
   },
- //toolbarsecondary: {
-   // justifyContent: "space-around",
-  //  overflowX: "auto",
- // },
+ toolbarSecondary: {
+    justifyContent: "space-around",
+    overflowX: "auto",
+  },
   toolbarLink: {
     padding: theme.spacing(1),
     flexShrink: 0,
@@ -37,16 +37,15 @@ const useStyles = makeStyles((theme) => ({
     },
     toolbarsecondary:{
       display: "flex",
-      justifyContent: "space-around",
-      overflowX: "auto",
+    //  justifyContent: "space-around",
+    //  overflowX: "auto",
       width: "100%",
       backgroundColor: theme.palette.text.default,
-      opacity: "1",
       flexDirection: " column",
-      justifyContent: "center",
+     // justifyContent: "center",
       alignContent: "center",
       position: "absolute",
-      display: "column",
+    //  display: "column",
     
     },
     navbutton:{
@@ -190,3 +189,8 @@ const Header = ({ title, toggleTheme }) => {
 };
 
 export default Header;
+
+/*
+  The issue right now is that since i changed the navbar class toolbarsecondary instead of toolbarSecondary on line 161, on the desktop view, the tags are not equally apart. On the mobile view it is fine.
+
+*/

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -21,8 +21,7 @@ const useStyles = makeStyles((theme) => ({
     top: "0",
     width: "100%",
     backgroundColor: theme.palette.background.default,
-    boxShadow: "2px 2px 5px grey",
-    zIndex: "1",
+    zIndex: "2",
   },
   toolbarTitle: {
     flex: 1,
@@ -35,7 +34,8 @@ const useStyles = makeStyles((theme) => ({
     opacity: "1",
     position: "fixed",
     top: "60px",
-    zIndex: "0",
+    zIndex: "1",
+    boxShadow: "2px 2px 5px grey",
   },
   toolbarLink: {
     padding: theme.spacing(1),
@@ -49,12 +49,17 @@ const useStyles = makeStyles((theme) => ({
   },
   "@media (max-width: 590px)": {
     wrapper: {
+      position: "fixed",
       width: "100%",
+      height: "100%",
+      backgroundColor: "grey",
+      zIndex: "0",
+      opacity: "0.3",
     },
     toolbar: {
       backgroundColor: theme.palette.background.header,
       boxShadow: "2px 2px 5px grey",
-      zIndex: "1",
+      zIndex: "2",
     },
     toolbarTitle: {
       display: "flex",
@@ -71,7 +76,7 @@ const useStyles = makeStyles((theme) => ({
       alignContent: "center",
       position: "fixed",
       top: "56px",
-      zIndex: "0",
+      zIndex: "1",
     },
     navbutton:{
       display:"column",
@@ -133,8 +138,10 @@ const Header = ({ title, toggleTheme }) => {
   let [NavDisplay, setNavDisplay] = useState("none");
   useEffect(() => {
     let navbar = document.getElementById("toolbarsecondary");
+    let wrapper = document.getElementById("wrapper");
     if(query.matches){
       navbar.style.display = NavDisplay;
+      wrapper.style.display = NavDisplay;
     }
   });
   const changenav = () =>{
@@ -180,11 +187,7 @@ const Header = ({ title, toggleTheme }) => {
           className={classes.navbutton}
           id = "navbutton"
           onClick = {() => {
-              if(NavDisplay === "none"){
-                setNavDisplay("flex");
-              }else {
-                setNavDisplay("none");
-              }
+              (NavDisplay === "none" ? setNavDisplay("flex") : setNavDisplay("none"));
             }}
         >
           <Typography
@@ -229,13 +232,18 @@ const Header = ({ title, toggleTheme }) => {
             {link}
           </NavLink>
         ))}
-
         <IconButton onClick={toggleTheme}>
           <Brightness6Icon variant="outline" color="secondary" />
         </IconButton>
       </Toolbar>
+      <Typography
+        variant= "button"
+        className = {classes.wrapper}
+        id = "wrapper"
+        onClick = {() => {
+          (NavDisplay === "none" ? setNavDisplay("flex") : setNavDisplay("none"));}}
+      ></Typography>
     </>
   );
 };
-
 export default Header;

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -34,26 +34,24 @@ const useStyles = makeStyles((theme) => ({
   },
   "@media (max-width: 590px)": {
     wrapper: {
-      marginRight: "auto", /* 1 */
-      marginLeft: "auto",
-      backgroundColor: "black",
-      opacity: "1",
+      width: "100%",
     },
     toolbar: {
       position: "fixed",
       top: "0",
       width: "100%",
+      backgroundColor: "white",
     },
     toolbarTitle: {
       display: "flex",
       justifyContent: "flex-start",
       width: "10px",
+      backgroundColor: "white",
     },
     toolbarsecondary:{
       display: "none",
-      overflowX: "auto",
       width: "100%",
-      backgroundColor: theme.palette.text.default,
+      backgroundColor: "white",
       opacity: "1",
       flexDirection: "column",
       justifyContent: "center",

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -52,7 +52,7 @@ const useStyles = makeStyles((theme) => ({
       position: "fixed",
       width: "100%",
       height: "100%",
-      backgroundColor: "grey",
+      backgroundColor: "black",
       zIndex: "0",
       opacity: "0.3",
     },

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Link as GatsbyLink, useStaticQuery, graphql } from "gatsby";
 import { makeStyles } from "@material-ui/core/styles";
 import Toolbar from "@material-ui/core/Toolbar";
@@ -10,6 +10,7 @@ import Link from "@material-ui/core/Link";
 
 import Title from "../assets/images/the_icarus_luminari.png";
 import "../assets/styles/mobile-nav.css";
+import { constant } from "lodash";
 //import { getElementById } from "min-document";
 
 
@@ -54,7 +55,7 @@ const useStyles = makeStyles((theme) => ({
       width: "100%",
       backgroundColor: theme.palette.text.default,
       opacity: "1",
-      flexDirection: " column",
+      flexDirection: "column",
       justifyContent: "center",
       alignContent: "center",
       position: "fixed",
@@ -114,6 +115,23 @@ const Header = ({ title, toggleTheme }) => {
       }
     }
   `);
+  const query = window.matchMedia('(max-width: 590px)');
+  let [NavDisplay, setNavDisplay] = useState("none");
+  useEffect(() => {
+    let navbar = document.getElementById("toolbarsecondary");
+    if(query.matches){
+      navbar.style.display = NavDisplay;
+    }
+  });
+  const changenav = () =>{
+    let navbar = document.getElementById("toolbarsecondary");
+    if(query.matches){
+      setNavDisplay("none");
+    }else{
+      navbar.style.display = "flex";
+    }
+  }
+  query.addListener(changenav);
 
   
 
@@ -122,90 +140,85 @@ const Header = ({ title, toggleTheme }) => {
   const classes = useStyles();
   return (
     <>
-      <Typography
-        variant= "div"
-        className = {classes.wrapper}
-      >
-        <Toolbar className={classes.toolbar}>
-          <Typography
-            variant="h3"
-            color="textSecondary"
-            align="center"
-            noWrap
-            className={classes.toolbarTitle}
-          >
-            <Link
-              to="/"
-              component={GatsbyLink}
-              color="inherit"
-              className={classes.link}
-            >
-              <img src={Title} alt={title} />
-            </Link>
-          </Typography>
-          <Typography
-            variant="button"
-            color="secondary"
-            align="right"
-            noWrap
-            className={classes.navbutton}
-            id = "navbutton"
-            onClick = {() => {
-              let x = "toolbarsecondary"
-              if(document.getElementById(x).style.display === "flex"){
-              document.getElementById(x).style.display = "none";
-            }else {
-              document.getElementById(x).style.display = "flex";
-            }}}
-          >
-            <Typography
-            className={classes.hamburger}
-            id = "topline"
-            >
-            </Typography>
-            <Typography
-            className={classes.hamburger}
-            id = "middleline"
-            >
-            </Typography>
-            <Typography
-            className={classes.hamburger}
-            id = "bottomline"
-            >
-            </Typography>
-          </Typography>
-        </Toolbar>
-        <Divider classes={{ root: classes.divider }} />
-        <Toolbar
-          component="nav"
-          variant="dense"
-          className={classes.toolbarsecondary}
-          id = "toolbarsecondary"
+      <Toolbar className={classes.toolbar}>
+        <Typography
+          variant="h3"
+          color="textSecondary"
+          align="center"
+          noWrap
+          className={classes.toolbarTitle}
         >
-          {tags.map((link) => (
-            <NavLink 
-              className={classes.toolbarLink} 
-              to={`/tag/${normalizeURL(link)}`}
-              key={link}
-            >
-              {link}
-            </NavLink>
-          ))}
-          {links.map((link) => (
-            <NavLink 
-              className={classes.toolbarLink} 
-              to={`/${normalizeURL(link)}`}
-              key={link}
-            >
-              {link}
-            </NavLink>
-          ))}
+          <Link
+            to="/"
+            component={GatsbyLink}
+            color="inherit"
+            className={classes.link}
+          >
+            <img src={Title} alt={title} />
+          </Link>
+        </Typography>
+        <Typography
+          variant="button"
+          color="secondary"
+          align="right"
+          noWrap
+          className={classes.navbutton}
+          id = "navbutton"
+          onClick = {() => {
+              if(NavDisplay === "none"){
+                setNavDisplay("flex");
+              }else {
+                setNavDisplay("none");
+              }
+            }}
+        >
+          <Typography
+          className={classes.hamburger}
+          id = "topline"
+          >
+          </Typography>
+          <Typography
+          className={classes.hamburger}
+          id = "middleline"
+          >
+          </Typography>
+          <Typography
+          className={classes.hamburger}
+          id = "bottomline"
+          >
+          </Typography>
+        </Typography>
+      </Toolbar>
+      <Divider classes={{ root: classes.divider }} />
+      <Toolbar
+        component="nav"
+        variant="dense"
+        className={classes.toolbarsecondary}
+        id = "toolbarsecondary"
+      >
+        {tags.map((link) => (
+          <NavLink 
+            className={classes.toolbarLink} 
+            to={`/tag/${normalizeURL(link)}`}
+            key={link}
+          >
+            {link}
+          </NavLink>
+        ))}
+        {links.map((link) => (
+          <NavLink 
+            className={classes.toolbarLink} 
+            to={`/${normalizeURL(link)}`}
+            key={link}
+          >
+            {link}
+          </NavLink>
+        ))}
 
-          <IconButton onClick={toggleTheme}>
-            <Brightness6Icon variant="outline" color="secondary" />
-          </IconButton>
-        </Toolbar>
-      </Typography>
+        <IconButton onClick={toggleTheme}>
+          <Brightness6Icon variant="outline" color="secondary" />
+        </IconButton>
+      </Toolbar>
     </>
   );
 };

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -15,14 +15,15 @@ import "../assets/styles/mobile-nav.css";
 
 
 const useStyles = makeStyles((theme) => ({
-  toolbar: {},
+  toolbar: {
+  },
   toolbarTitle: {
     flex: 1,
   },
- //toolbarsecondary: {
-   // justifyContent: "space-around",
-  //  overflowX: "auto",
- // },
+  toolbarsecondary: {
+    justifyContent: "space-around",
+    overflowX: "auto",
+  },
   toolbarLink: {
     padding: theme.spacing(1),
     flexShrink: 0,
@@ -31,13 +32,18 @@ const useStyles = makeStyles((theme) => ({
     background: theme.palette.text.secondary,
   },
   "@media (max-width: 590px)": {
+    toolbar: {
+      position: "fixed",
+      top: "0",
+      width: "100%",
+    },
     toolbarTitle: {
       display: "flex",
       justifyContent: "flex-start",
+      width: "10px",
     },
     toolbarsecondary:{
       display: "flex",
-      justifyContent: "space-around",
       overflowX: "auto",
       width: "100%",
       backgroundColor: theme.palette.text.default,
@@ -45,12 +51,13 @@ const useStyles = makeStyles((theme) => ({
       flexDirection: " column",
       justifyContent: "center",
       alignContent: "center",
-      position: "absolute",
-      display: "column",
-    
+      position: "fixed",
+      top: "60px",
+      overflowY: "auto",
     },
     navbutton:{
-      display:"inline",
+      display:"column",
+      width: "20%",
     },
     hamburger: {
       display:"block",

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -96,7 +96,7 @@ const useStyles = makeStyles((theme) => ({
       display: "none",
     },
     box:{
-     // boxShadow: "none",
+      boxShadow: "none",
       width: "40px",
     },
 
@@ -201,9 +201,11 @@ const Header = ({ title, toggleTheme }) => {
         <Typography id = "box" className = {classes.box}
           
          onMouseEnter = {()=>{
-           document.getElementById("box").style.setBoxShadow("2px 2px 5px grey");
+           document.getElementById("box").style.boxShadow="20px 20px 70px 15px grey"       }
          }
-         }
+         onMouseLeave = {()=>{
+          document.getElementById("box").style.boxShadow="none";  
+         }}
     
         
         >

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -46,22 +46,26 @@ const useStyles = makeStyles((theme) => ({
       width: "100%",
     },
     toolbar: {
+      backgroundColor: theme.palette.background.header,
+      boxShadow: "2px 2px 5px grey",
+      zIndex: "1",
     },
     toolbarTitle: {
       display: "flex",
       justifyContent: "flex-start",
       width: "10px",
-      backgroundColor: theme.palette.background.default,
+      backgroundColor: theme.palette.background.header,
     },
     toolbarsecondary:{
       display: "none",
-      backgroundColor: theme.palette.background.default,
+      backgroundColor: theme.palette.background.header,
       opacity: "1",
       flexDirection: "column",
       justifyContent: "center",
       alignContent: "center",
       position: "fixed",
       top: "50px",
+      zIndex: "0",
     },
     navbutton:{
       display:"column",
@@ -128,6 +132,7 @@ const Header = ({ title, toggleTheme }) => {
   const changenav = () =>{
     let navbar = document.getElementById("toolbarsecondary");
     if(query.matches){
+      navbar.style.display = "none";
       setNavDisplay("none");
     }else{
       navbar.style.display = "flex";

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -7,10 +7,9 @@ import IconButton from "@material-ui/core/IconButton";
 import Brightness6Icon from "@material-ui/icons/Brightness6";
 import Typography from "@material-ui/core/Typography";
 import Link from "@material-ui/core/Link";
-
 import Title from "../assets/images/the_icarus_luminari.png";
 import "../assets/styles/mobile-nav.css";
-import { constant } from "lodash";
+
 //import { getElementById } from "min-document";
 
 
@@ -89,12 +88,18 @@ const useStyles = makeStyles((theme) => ({
       height: "6px",
       borderRadius: "5px",
       margin: "7px 0px",
+
     },
     divider: {
       marginTop: theme.spacing(7),
       position: "fixed",
       display: "none",
     },
+    box:{
+     // boxShadow: "none",
+      width: "40px",
+    },
+
   },
 }));
 
@@ -139,6 +144,7 @@ const Header = ({ title, toggleTheme }) => {
   useEffect(() => {
     let navbar = document.getElementById("toolbarsecondary");
     let wrapper = document.getElementById("wrapper");
+ 
     if(query.matches){
       navbar.style.display = NavDisplay;
       wrapper.style.display = NavDisplay;
@@ -160,6 +166,8 @@ const Header = ({ title, toggleTheme }) => {
   const links = site.siteMetadata.navbar.links;
   const tags = site.siteMetadata.navbar.tags;
   const classes = useStyles();
+ 
+
   return (
     <>
       <Toolbar className={classes.toolbar}>
@@ -190,6 +198,15 @@ const Header = ({ title, toggleTheme }) => {
               (NavDisplay === "none" ? setNavDisplay("flex") : setNavDisplay("none"));
             }}
         >
+        <Typography id = "box" className = {classes.box}
+          
+         onMouseEnter = {()=>{
+           document.getElementById("box").style.setBoxShadow("2px 2px 5px grey");
+         }
+         }
+    
+        
+        >
           <Typography
           className={classes.hamburger}
           id = "topline"
@@ -206,6 +223,7 @@ const Header = ({ title, toggleTheme }) => {
           >
           </Typography>
         </Typography>
+      </Typography>
       </Toolbar>
       <Divider classes={{ root: classes.divider }} />
       <Toolbar

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -75,7 +75,7 @@ const NavLink = (props) => (
     to={props.to}
     component={GatsbyLink}
     color="textSecondary"
-    noWrap
+    white-space = "nowrap"
     variant="h5"
     className={props.className}
   >
@@ -107,7 +107,7 @@ const Header = ({ title, toggleTheme }) => {
           variant="h3"
           color="textSecondary"
           align="center"
-          noWrap
+          white-space =  "nowrap"
           className={classes.toolbarTitle}
         >
           <Link
@@ -123,10 +123,10 @@ const Header = ({ title, toggleTheme }) => {
           variant="button"
           color="secondary"
           align="right"
-          nowrap
+          white-space = "nowrap"
           className={classes.navbutton}
           id = "navbutton"
-          onClick = {() => {"toolbarsecondary".toggle('active');}}
+          onClick = {() => {'toolbarsecondary'.toggle('active');}}
         >
           <Typography
           className={classes.hamburger}

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -10,6 +10,7 @@ import Link from "@material-ui/core/Link";
 
 import Title from "../assets/images/the_icarus_luminari.png";
 import "../assets/styles/mobile-nav.css";
+import { getElementById } from "min-document";
 
 
 
@@ -28,9 +29,6 @@ const useStyles = makeStyles((theme) => ({
   },
   divider: {
     background: theme.palette.text.secondary,
-  },
-  navbutton:{
-    display:"none",
   },
   "@media (max-width: 590px)": {
     toolbarTitle: {
@@ -126,7 +124,12 @@ const Header = ({ title, toggleTheme }) => {
           white-space = "nowrap"
           className={classes.navbutton}
           id = "navbutton"
-          onClick = {() => {'toolbarsecondary'.toggle('active');}}
+          onClick = {() => {
+            if(document.getElementById("toolbarsecondary").style.display === "none"){
+            document.getElementById("toolbarsecondary").style.display = "column";
+          }else{
+            document.getElementById("toolbarsecondary").style.display = "none";
+          }}}
         >
           <Typography
           className={classes.hamburger}

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -17,14 +17,23 @@ import { constant } from "lodash";
 
 const useStyles = makeStyles((theme) => ({
   toolbar: {
+    position: "fixed",
+    top: "0",
+    width: "100%",
+    backgroundColor: theme.palette.background.default,
   },
   toolbarTitle: {
     flex: 1,
   },
   toolbarsecondary: {
-  justifyContent: "space-around",
-  overflowX: "auto",
- },
+    justifyContent: "space-around",
+    overflowX: "auto",
+    width: "100%",
+    backgroundColor: theme.palette.background.default,
+    opacity: "1",
+    position: "fixed",
+    top: "50px",
+  },
   toolbarLink: {
     padding: theme.spacing(1),
     flexShrink: 0,
@@ -37,21 +46,16 @@ const useStyles = makeStyles((theme) => ({
       width: "100%",
     },
     toolbar: {
-      position: "fixed",
-      top: "0",
-      width: "100%",
-      backgroundColor: "white",
     },
     toolbarTitle: {
       display: "flex",
       justifyContent: "flex-start",
       width: "10px",
-      backgroundColor: "white",
+      backgroundColor: theme.palette.background.default,
     },
     toolbarsecondary:{
       display: "none",
-      width: "100%",
-      backgroundColor: "white",
+      backgroundColor: theme.palette.background.default,
       opacity: "1",
       flexDirection: "column",
       justifyContent: "center",

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -21,6 +21,8 @@ const useStyles = makeStyles((theme) => ({
     top: "0",
     width: "100%",
     backgroundColor: theme.palette.background.default,
+    boxShadow: "2px 2px 5px grey",
+    zIndex: "1",
   },
   toolbarTitle: {
     flex: 1,
@@ -32,7 +34,8 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: theme.palette.background.default,
     opacity: "1",
     position: "fixed",
-    top: "50px",
+    top: "60px",
+    zIndex: "0",
   },
   toolbarLink: {
     padding: theme.spacing(1),
@@ -40,6 +43,9 @@ const useStyles = makeStyles((theme) => ({
   },
   divider: {
     background: theme.palette.text.secondary,
+    position: "fixed",
+    zIndex: "2",
+    top: "100px",
   },
   "@media (max-width: 590px)": {
     wrapper: {
@@ -64,7 +70,7 @@ const useStyles = makeStyles((theme) => ({
       justifyContent: "center",
       alignContent: "center",
       position: "fixed",
-      top: "50px",
+      top: "56px",
       zIndex: "0",
     },
     navbutton:{
@@ -80,7 +86,9 @@ const useStyles = makeStyles((theme) => ({
       margin: "7px 0px",
     },
     divider: {
-      marginTop: theme.spacing(7)
+      marginTop: theme.spacing(7),
+      position: "fixed",
+      display: "none",
     },
   },
 }));

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -36,7 +36,7 @@ const useStyles = makeStyles((theme) => ({
     wrapper: {
       marginRight: "auto", /* 1 */
       marginLeft: "auto",
-      backgroundColor: "white",
+      backgroundColor: "black",
       opacity: "1",
     },
     toolbar: {

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -119,7 +119,7 @@ const Header = ({ title, toggleTheme }) => {
             <img src={Title} alt={title} />
           </Link>
         </Typography>
-        <Typography 
+        <Typography
           variant="button"
           color="secondary"
           align="right"

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -9,6 +9,9 @@ import Typography from "@material-ui/core/Typography";
 import Link from "@material-ui/core/Link";
 
 import Title from "../assets/images/the_icarus_luminari.png";
+import "../assets/styles/mobile-nav.css";
+
+
 
 const useStyles = makeStyles((theme) => ({
   toolbar: {},
@@ -16,7 +19,7 @@ const useStyles = makeStyles((theme) => ({
     flex: 1,
   },
   toolbarSecondary: {
-    justifyContent: "space-between",
+    justifyContent: "space-around",
     overflowX: "auto",
   },
   toolbarLink: {
@@ -25,6 +28,35 @@ const useStyles = makeStyles((theme) => ({
   },
   divider: {
     background: theme.palette.text.secondary,
+  },
+  navbutton:{
+    display:"none",
+  },
+  "@media (max-width: 590px)": {
+    toolbarTitle: {
+      display: "flex",
+      justifyContent: "flex-start",
+    },
+    toolbarSecondary:{
+      width: "100%",
+      backgroundColor: theme.palette.background.default,
+      flexDirection: "column",
+      justifyContent: "center",
+      alignContent: "center",
+      position: "absolute",
+      display: "column",
+    },
+    navbutton:{
+      display:"inline",
+    },
+    hamburger: {
+      display:"block",
+      backgroundColor: theme.palette.text.secondary,
+      width: "40px",
+      height: "6px",
+      borderRadius: "5px",
+      margin: "7px 0px",
+    },
   },
 }));
 
@@ -87,12 +119,38 @@ const Header = ({ title, toggleTheme }) => {
             <img src={Title} alt={title} />
           </Link>
         </Typography>
+        <Typography 
+          variant="button"
+          color="secondary"
+          align="right"
+          nowrap
+          className={classes.navbutton}
+          id = "navbutton"
+          onClick = {() => {"toolbarsecondary".toggle('active');}}
+        >
+          <Typography
+          className={classes.hamburger}
+          id = "topline"
+          >
+          </Typography>
+          <Typography
+          className={classes.hamburger}
+          id = "middleline"
+          >
+          </Typography>
+          <Typography
+          className={classes.hamburger}
+          id = "bottomline"
+          >
+          </Typography>
+        </Typography>
       </Toolbar>
       <Divider classes={{ root: classes.divider }} />
       <Toolbar
         component="nav"
         variant="dense"
         className={classes.toolbarSecondary}
+        id = "toolbarsecondary"
       >
         {tags.map((link) => (
           <NavLink 

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -10,7 +10,7 @@ import Link from "@material-ui/core/Link";
 
 import Title from "../assets/images/the_icarus_luminari.png";
 import "../assets/styles/mobile-nav.css";
-import { getElementById } from "min-document";
+//import { getElementById } from "min-document";
 
 
 
@@ -19,10 +19,10 @@ const useStyles = makeStyles((theme) => ({
   toolbarTitle: {
     flex: 1,
   },
-  toolbarSecondary: {
-    justifyContent: "space-around",
-    overflowX: "auto",
-  },
+ //toolbarsecondary: {
+   // justifyContent: "space-around",
+  //  overflowX: "auto",
+ // },
   toolbarLink: {
     padding: theme.spacing(1),
     flexShrink: 0,
@@ -35,14 +35,19 @@ const useStyles = makeStyles((theme) => ({
       display: "flex",
       justifyContent: "flex-start",
     },
-    toolbarSecondary:{
+    toolbarsecondary:{
+      display: "flex",
+      justifyContent: "space-around",
+      overflowX: "auto",
       width: "100%",
-      backgroundColor: theme.palette.background.default,
-      flexDirection: "column",
+      backgroundColor: theme.palette.text.default,
+      opacity: "1",
+      flexDirection: " column",
       justifyContent: "center",
       alignContent: "center",
       position: "absolute",
       display: "column",
+    
     },
     navbutton:{
       display:"inline",
@@ -73,7 +78,7 @@ const NavLink = (props) => (
     to={props.to}
     component={GatsbyLink}
     color="textSecondary"
-    white-space = "nowrap"
+    noWrap
     variant="h5"
     className={props.className}
   >
@@ -105,7 +110,7 @@ const Header = ({ title, toggleTheme }) => {
           variant="h3"
           color="textSecondary"
           align="center"
-          white-space =  "nowrap"
+          noWrap
           className={classes.toolbarTitle}
         >
           <Link
@@ -121,14 +126,16 @@ const Header = ({ title, toggleTheme }) => {
           variant="button"
           color="secondary"
           align="right"
-          white-space = "nowrap"
+          noWrap
           className={classes.navbutton}
           id = "navbutton"
           onClick = {() => {
-            if(document.getElementById("toolbarsecondary").style.display === "none"){
-            document.getElementById("toolbarsecondary").style.display = "column";
-          }else{
-            document.getElementById("toolbarsecondary").style.display = "none";
+            let x = "toolbarsecondary"
+            if(document.getElementById(x).style.display === "flex"){
+            document.getElementById(x).style.display = "none";
+
+          }else {
+            document.getElementById(x).style.display = "flex";
           }}}
         >
           <Typography
@@ -152,7 +159,7 @@ const Header = ({ title, toggleTheme }) => {
       <Toolbar
         component="nav"
         variant="dense"
-        className={classes.toolbarSecondary}
+        className={classes.toolbarsecondary}
         id = "toolbarsecondary"
       >
         {tags.map((link) => (

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -40,12 +40,12 @@ const Layout = ({ content, toggleTheme, themeType }) => {
       <div className={classes.root}>
         <Container maxWidth="lg">
           <main className={classes.main}>{content}</main>
-          <Header
+        </Container>
+        <Header
             toggleTheme={toggleTheme}
             themeType={themeType}
             title={title}
           />
-        </Container>
       </div>
       <Container maxWidth="lg">
         <Footer title={title} />

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -45,7 +45,7 @@ const Layout = ({ content, toggleTheme, themeType }) => {
             toggleTheme={toggleTheme}
             themeType={themeType}
             title={title}
-          />
+        />
       </div>
       <Container maxWidth="lg">
         <Footer title={title} />

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -39,12 +39,12 @@ const Layout = ({ content, toggleTheme, themeType }) => {
       <CssBaseline />
       <div className={classes.root}>
         <Container maxWidth="lg">
+          <main className={classes.main}>{content}</main>
           <Header
             toggleTheme={toggleTheme}
             themeType={themeType}
             title={title}
           />
-          <main className={classes.main}>{content}</main>
         </Container>
       </div>
       <Container maxWidth="lg">

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles((theme) => ({
     minHeight: "85vh",
   },
   main: {
-    marginTop: theme.spacing(1.125),
+    marginTop: theme.spacing(14),
   },
 }));
 

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -15,7 +15,12 @@ const useStyles = makeStyles((theme) => ({
     minHeight: "85vh",
   },
   main: {
-    marginTop: theme.spacing(1.125),
+    marginTop: theme.spacing(14),
+  },
+  "@media (max-width: 590px)": {
+    main: {
+      marginTop: theme.spacing(10),
+    },
   },
 }));
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -34,7 +34,8 @@ const makeTheme = (variant) => {
 const light = {
   palette: {
     background: {
-      default: "#ebeaeb",
+      default: "#e3e3e3",
+      header: "#ebebeb",
       paper: "#fff",
     },
     text: {
@@ -51,6 +52,7 @@ const dark = {
   palette: {
     background: {
       default: "#303030",
+      header: "3d3d3d",
       paper: "#424242",
     },
     text: {


### PR DESCRIPTION
## :scroll: Description

We created a navbar for people going to our website through a mobile device or small screen.
For those people, The Icarus logo is shifted to the left of the header and there is a button on the right side. When the button is clicked, the list will pop up (Daedalus, Tech, NYC ... ). The color for the header is also a little lighter than the rest of the page with a shadow effect to separate them. 

## Features
When the list button is clicked, a vertical list will pop up and everything underneath it will be dark. The user is allowed to close the list by clicking the same button that opened it, or the dark area under the list. The header also sticks to top of the screen when the user scrolls up and down the page.

## Next Steps

We can try to implement a search in the list along with the others in the header.
Animations for buttons would also be good to add as well.

## :camera: Screenshots / GIFs / Videos
<img src = "https://user-images.githubusercontent.com/64699846/127779645-9b39e997-1d0e-41a6-987a-83d3ec920896.png" width = "400" height = "800"><img src = "https://user-images.githubusercontent.com/64699846/127779687-693dbe2b-c988-4264-b8e2-f2f63cf3d970.png" width = "400" height = "800">
<img src = "https://user-images.githubusercontent.com/64699846/127779703-ec70339b-46d7-41ab-9de0-2065ceae3a69.png" width = "400" height = "800"><img src = "https://user-images.githubusercontent.com/64699846/127779711-bd1c8364-5a31-4a4e-b817-cbaafe0328a3.png" width = "400" height = "800">